### PR TITLE
Superbuild

### DIFF
--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -42,6 +42,7 @@ ExternalProject_Add(anari
 ExternalProject_Add(anari-ospray
   SOURCE_SUBDIR ../../../../
   DOWNLOAD_COMMAND ""
+  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/anari-ospray
   CMAKE_ARGS
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -11,6 +11,12 @@ endif()
 
 include(ExternalProject)
 
+## Superbuild options ##
+
+option(BUILD_ANARI_SDK_VIEWER "Build interactive viewer app (requires GLFW)" OFF)
+option(BUILD_TBB_FROM_SOURCE "Build TBB from source or use pre-built version?" OFF)
+option(BUILD_EMBREE_FROM_SOURCE "Build Embree or use pre-built version?" OFF)
+
 ExternalProject_Add(ospray
   URL https://github.com/ospray/ospray/archive/devel.zip
   SOURCE_SUBDIR scripts/superbuild
@@ -18,7 +24,8 @@ ExternalProject_Add(ospray
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
     -DINSTALL_IN_SEPARATE_DIRECTORIES=OFF
-    -DBUILD_EMBREE_FROM_SOURCE=OFF
+    -DBUILD_EMBREE_FROM_SOURCE=${BUILD_EMBREE_FROM_SOURCE}
+    -DBUILD_TBB_FROM_SOURCE=${BUILD_TBB_FROM_SOURCE}
     -DBUILD_GLFW=OFF
     -DBUILD_OSPRAY_APPS=OFF
   INSTALL_COMMAND ""
@@ -29,6 +36,7 @@ ExternalProject_Add(anari
   CMAKE_ARGS
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    -DBUILD_VIEWER=${BUILD_ANARI_SDK_VIEWER}
 )
 
 ExternalProject_Add(anari-ospray

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -37,6 +37,7 @@ ExternalProject_Add(anari
     -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
     -DBUILD_VIEWER=${BUILD_ANARI_SDK_VIEWER}
+  INSTALL_COMMAND ""
 )
 
 ExternalProject_Add(anari-ospray


### PR DESCRIPTION
These are a couple of fixes to make the `superbuild` run more smoothly for me. As I'm on ARM Mac, I need to build TBB and Embree from source, so I added `cmake` `option`s for that.

I had some issues with adding the (meta) project itself as an external dependency, as is done by the `superbuild` script. In particular, it would try to build the device library in-source, which is however deactivated by the project. I fixed that by specifying a `BINARY_DIR` inside the current build dir, but I'm not sure if this is desirable. That way, the project builds successfully for me, but solving the issue this way might be a bit controversial, so just let me know if you want this solved differently / want me to use different paths / naming conventions etc.

In regards to the latter, the docs say that if `SOURCEDIR` is specified `cmake` will deduce the other variables from that (cf. https://cmake.org/cmake/help/latest/module/ExternalProject.html, "If any of the above ..._DIR options are not specified, their defaults are computed as follows. [..]"), but I found that (seemingly) this is not the case, at least with my `cmake` version (which is 3.20.3).