### PR TITLE
Build device library as SHARED, not MODULE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ include(GNUInstallDirs)
 find_package(ospray 2.9.0 REQUIRED)
 find_package(anari REQUIRED)
 
-add_library(${PROJECT_NAME} MODULE
+add_library(${PROJECT_NAME} SHARED
   OSPRayDevice.cpp
 
   Object.cpp


### PR DESCRIPTION
On macOS, with `add_library(MODULE ...)`, `cmake` creates an `.so` file instead of using the ending `.dylib`. `ANARI-SDK` does not parse that correctly on `dlopen`ing the device library, but instead expects a `.dylib` on macOS.

For some context, also see this issue here: https://gitlab.kitware.com/cmake/cmake/-/issues/21189

Changing the output target type to `SHARED` was the easiest fix (also what the `ANARI` `example_device` does) . Alternatively, one could also use `CMAKE_SHARED_MODULE_SUFFIX`.

As another alternative, I could probably also push for `ANARI` parsing this correctly in the first place. Just let me know which option you prefer.