### PR TITLE
Reset current frame pointer after rendering has finished

### DIFF
--- a/frame/Frame.cpp
+++ b/frame/Frame.cpp
@@ -187,6 +187,7 @@ void Frame::wait() const
     m_duration = ospGetTaskDuration(m_osprayFuture);
     ospRelease(m_osprayFuture);
     m_osprayFuture = nullptr;
+    deviceState()->currentFrame = nullptr;
   }
 }
 


### PR DESCRIPTION
In my application I observe crashes within the anari-ospray/OSPRay code, which are probably due to a bug. This pull request proposes a fix for it.

I render a series of images using an OSPRay ANARI device (which is reused). For each image a new `Frame` object is created and then released immediately after rendering is complete. The internal `OSPRayGlobalState::currentFrame` pointer does not seem to get updated and still points to the already destroyed `Frame` object after rendering the first image. When trying to render the next image, this leads to a crash in `Frame::renderFrame()`, which calls `state->waitOnCurrentFrame()` to wait for the previous frame to finish.