### PR TITLE
Fix parameter name for setting spatial fields

### DIFF
--- a/scene/volume/TransferFunction1D.cpp
+++ b/scene/volume/TransferFunction1D.cpp
@@ -18,7 +18,7 @@ TransferFunction1DVolume::~TransferFunction1DVolume()
 
 void TransferFunction1DVolume::commit()
 {
-  m_field = getParamObject<SpatialField>("field");
+  m_field = getParamObject<SpatialField>("value");
   if (!m_field) {
     reportMessage(
         ANARI_SEVERITY_WARNING, "no spatial field provided to scivis volume");


### PR DESCRIPTION
This has changed from "field" to "value" with the 1.0 release