### PR TITLE
Add quad light

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ project_sources(PRIVATE
   scene/light/Directional.cpp
   scene/light/Light.cpp
   scene/light/Point.cpp
+  scene/light/Quad.cpp
   scene/light/Spot.cpp
   scene/surface/Surface.cpp
   scene/surface/geometry/Cone.cpp

--- a/scene/light/Light.cpp
+++ b/scene/light/Light.cpp
@@ -5,6 +5,7 @@
 // subtypes
 #include "Directional.h"
 #include "Point.h"
+#include "Quad.h"
 #include "Spot.h"
 
 namespace anari_ospray {
@@ -27,6 +28,8 @@ Light *Light::createInstance(std::string_view subtype, OSPRayGlobalState *s)
     return new Directional(s);
   else if (subtype == "point")
     return new Point(s);
+  else if (subtype == "quad")
+    return new QuadLight(s);
   else if (subtype == "spot")
     return new Spot(s);
   else

--- a/scene/light/Quad.cpp
+++ b/scene/light/Quad.cpp
@@ -1,0 +1,33 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include "Quad.h"
+
+namespace anari_ospray {
+
+QuadLight::QuadLight(OSPRayGlobalState *s) : Light(s, "quad") {}
+
+void QuadLight::commit()
+{
+  Light::commit();
+
+  auto color = getParam<float3>("color", float3(1, 1, 1));
+  auto visible = getParam<bool>("visible", true);
+  auto position = getParam<float3>("position", float3(0, 0, 0));
+  auto edge1 = getParam<float3>("edge1", float3(1, 0, 0));
+  auto edge2 = getParam<float3>("edge2", float3(0, 1, 0));
+  auto intensity = std::clamp(getParam<float>("intensity", 1.f),
+      0.f,
+      std::numeric_limits<float>::max());
+
+  auto ol = osprayLight();
+  ospSetParam(ol, "color", OSP_VEC3F, &color);
+  ospSetParam(ol, "visible", OSP_BOOL, &visible);
+  ospSetParam(ol, "position", OSP_VEC3F, &position);
+  ospSetParam(ol, "edge1", OSP_VEC3F, &edge1);
+  ospSetParam(ol, "edge2", OSP_VEC3F, &edge2);
+  ospSetParam(ol, "intensity", OSP_FLOAT, &intensity);
+  ospCommit(ol);
+}
+
+} // namespace anari_ospray

--- a/scene/light/Quad.h
+++ b/scene/light/Quad.h
@@ -1,0 +1,16 @@
+// Copyright 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "Light.h"
+
+namespace anari_ospray {
+
+struct QuadLight : public Light
+{
+  QuadLight(OSPRayGlobalState *d);
+  void commit() override;
+};
+
+} // namespace anari_ospray


### PR DESCRIPTION
Exposes quad lights.

Note the reason for calling the class `QuadLight` and not `Quad` was a name collision with the `Quad` geometry type, which would violate the one definition rule.