### PR TITLE
Don't try to commit surfaces with an invalid (isosurface) geometry on

### DIFF
--- a/scene/surface/Surface.cpp
+++ b/scene/surface/Surface.cpp
@@ -5,7 +5,8 @@
 
 namespace anari_ospray {
 
-Surface::Surface(OSPRayGlobalState *s) : Object(ANARI_SURFACE, s)
+Surface::Surface(OSPRayGlobalState *s)
+    : Object(ANARI_SURFACE, s), m_geometry(this)
 {
   m_osprayModel = ospNewGeometricModel();
 }
@@ -25,7 +26,7 @@ void Surface::commit()
     return;
   }
 
-  if (!m_geometry) {
+  if (!m_geometry || !m_geometry->isValid()) {
     reportMessage(ANARI_SEVERITY_WARNING, "missing 'geometry' on ANARISurface");
     return;
   }
@@ -44,7 +45,7 @@ void Surface::commit()
 
 const Geometry *Surface::geometry() const
 {
-  return m_geometry.ptr;
+  return m_geometry.get();
 }
 
 const Material *Surface::material() const

--- a/scene/surface/Surface.h
+++ b/scene/surface/Surface.h
@@ -24,7 +24,7 @@ struct Surface : public Object
   OSPGeometricModel osprayModel() const;
 
  private:
-  helium::IntrusivePtr<Geometry> m_geometry;
+  helium::ChangeObserverPtr<Geometry> m_geometry;
   helium::IntrusivePtr<Material> m_material;
 
   OSPGeometricModel m_osprayModel{nullptr};

--- a/scene/surface/geometry/Isosurface.cpp
+++ b/scene/surface/geometry/Isosurface.cpp
@@ -13,6 +13,8 @@ void Isosurface::commit()
 {
   Geometry::commit();
 
+  m_isovalueValid = false;
+
   m_field = getParamObject<SpatialField>("field");
 
   if (!m_field) {
@@ -25,7 +27,8 @@ void Isosurface::commit()
 
   auto og = osprayGeometry();
 
-  if (m_isovalue) {
+  if (m_isovalue && m_isovalue->size() > 0
+      && m_isovalue->elementType() == ANARI_FLOAT32) {
     auto iv = m_isovalue->osprayData();
     ospSetParam(og, "isovalue", OSP_DATA, &iv);
   } else {
@@ -38,6 +41,8 @@ void Isosurface::commit()
     ospSetParam(og, "isovalue", OSP_FLOAT, &isovalue);
   }
 
+  m_isovalueValid = true;
+
   auto ov = m_field->osprayVolume();
   ospSetParam(og, "volume", OSP_VOLUME, &ov);
 
@@ -46,7 +51,7 @@ void Isosurface::commit()
 
 bool Isosurface::isValid() const
 {
-  return m_field && m_field->isValid();
+  return m_field && m_field->isValid() && m_isovalueValid;
 }
 
 } // namespace anari_ospray

--- a/scene/surface/geometry/Isosurface.h
+++ b/scene/surface/geometry/Isosurface.h
@@ -19,6 +19,8 @@ struct Isosurface : public Geometry
  private:
   helium::IntrusivePtr<SpatialField> m_field;
   helium::ChangeObserverPtr<Array1D> m_isovalue;
+
+  bool m_isovalueValid{false};
 };
 
 } // namespace anari_ospray


### PR DESCRIPTION
This would crash if the isosurface is momentarily invalid and a surface with it on gets committed. Note I made the geometry a commit observer on the surface, because subsequently the surface wouldn't get recommitted once the geometry becomes valid.

(Isosurfaces can be tested with the volume viewer: https://github.com/vtvamr/anari-volume-viewer, not sure if you have an app internally that can generate ANARI isosurfaces.)