### PR TITLE
Add Denoiser Feature to ANARI-OSPRay

### DIFF
--- a/renderer/Renderer.cpp
+++ b/renderer/Renderer.cpp
@@ -25,6 +25,9 @@ void Renderer::commit()
   m_bgColor = getParam<float4>("background", float4(float3(0.f), 1.f));
   m_ambientRadiance = getParam<float>("ambientRadiance", 0.f);
   m_ambientColor = getParam<float3>("ambientColor", float3(1, 1, 1));
+  m_denoiseEnabled = getParam<bool>("denoiser", false);
+  m_denoiseAlpha = getParam<bool>("denoiseAlpha", false);
+  m_denoiseQuality = getParam<std::string_view>("denoiseQuality", "medium");
   auto pixelSamples = getParam<int>("pixelSamples", 1);
   auto maxPathLength = getParam<int>("maxPathLength", 20);
   auto minContribution = getParam<float>("minContribution", 0.001f);
@@ -36,6 +39,11 @@ void Renderer::commit()
   ospSetInt(r, "maxPathLength", maxPathLength);
   ospSetFloat(r, "minContribution", minContribution);
   ospSetFloat(r, "varianceThreshold", varianceThreshold);
+
+  if(m_denoiseEnabled && ospLoadModule("denoiser") != OSP_NO_ERROR) {
+    m_denoiseEnabled = false;
+    reportMessage(ANARI_SEVERITY_WARNING, "denoiser requested but not available");
+  }
 }
 
 Renderer *Renderer::createInstance(
@@ -66,6 +74,21 @@ float Renderer::ambientRadiance() const
 float3 Renderer::ambientColor() const
 {
   return m_ambientColor;
+}
+
+bool Renderer::denoiserEnabled() const
+{
+  return m_denoiseEnabled;
+}
+
+bool Renderer::denoiseAlpha() const
+{
+  return m_denoiseAlpha;
+}
+
+std::string_view Renderer::denoiseQuality() const
+{
+  return m_denoiseQuality;
 }
 
 } // namespace anari_ospray

--- a/renderer/Renderer.h
+++ b/renderer/Renderer.h
@@ -22,10 +22,18 @@ struct Renderer : public Object
   float ambientRadiance() const;
   float3 ambientColor() const;
 
+  bool denoiserEnabled() const;
+  bool denoiseAlpha() const;
+  std::string_view denoiseQuality() const;
+
  private:
   float4 m_bgColor{float3(0.f), 1.f};
   float m_ambientRadiance{0.f};
   float3 m_ambientColor{1.f, 1.f, 1.f};
+  bool m_denoiseEnabled{false};
+  bool m_denoiseAlpha{false};
+  std::string_view m_denoiseQuality{"medium"};
+
 
   OSPRenderer m_osprayRenderer{nullptr};
 };


### PR DESCRIPTION
This PR introduces the denoising feature to ANARI-OSPRay, adding options for enabling denoising, controlling alpha denoising, and setting the denoise quality level. 

#### How it Works:

- **Enable Denoiser**: `anari::setParameter(d, renderer, "denoiser", false);`
  - Toggles denoising on or off. Default is false.
- **Denoise Alpha**: `anari::setParameter(d, renderer, "denoiseAlpha", false);`
  - Determines if the alpha channel should be denoised. Default is false.
- **Denoise Quality**: `anari::setParameter(d, renderer, "denoiseQuality", "medium");`
  - Sets the denoise quality level. Acceptable values include "low", "medium", and "high", with "medium" as the default.
