### PR TITLE
Accept amr block data as Array3D

### DIFF
--- a/scene/volume/spatial_field/AMRField.cpp
+++ b/scene/volume/spatial_field/AMRField.cpp
@@ -46,13 +46,13 @@ void AMRField::commit()
   if (m_block_data->elementType() != ANARI_ARRAY3D) {
     reportMessage(ANARI_SEVERITY_WARNING,
         "'block.data' on 'amr' field isn't ANARIArray3D");
-  }
 
-  if (m_block_data->elementType() == ANARI_ARRAY1D) {
-    reportMessage(ANARI_SEVERITY_WARNING,
-        "allowing 'block.data' to be ANARIArray1D on 'amr' field");
-  } else {
-    return;
+    if (m_block_data->elementType() == ANARI_ARRAY1D) {
+      reportMessage(ANARI_SEVERITY_WARNING,
+          "allowing 'block.data' to be ANARIArray1D on 'amr' field");
+    } else {
+      return;
+    }
   }
 
   auto origin = getParam<float3>("origin", float3(0.f));


### PR DESCRIPTION
If the block data is Array3D, the field's `commit` function will return here: https://github.com/ospray/anari-ospray/blob/main/scene/volume/spatial_field/AMRField.cpp#L55, which is a bug. The PR fixes this.